### PR TITLE
Fix type import in ComponentRenderer.svelte

### DIFF
--- a/src/lib/ComponentRenderer.svelte
+++ b/src/lib/ComponentRenderer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {onMount, SvelteComponent} from 'svelte';
+	import {onMount, type SvelteComponent} from 'svelte';
 	import {Subscribe} from 'svelte-subscribe';
 	import type {ComponentRenderConfig} from './createRender.js';
 	import PropsRenderer from './PropsRenderer.svelte';


### PR DESCRIPTION
This small change allows Svelte Headless Table to work with Svelte 5.